### PR TITLE
Add FridaScript.post(message, data) for sending messages to scripts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ interface HostSession {
 interface AgentSession {
     CreateScript(script: string, options: {}): Promise<[number]>;
     LoadScript(scriptId: [number]): Promise<void>;
+    PostMessages(messages: [AgentMessage], batchId: number): Promise<void>;
 }
 
 /**
@@ -342,6 +343,8 @@ export class FridaAgentSession {
     }
 }
 
+const ZERO_LENGTH_BUFFER = Buffer.alloc(0);
+
 export class FridaScript {
     constructor(
         private bus: dbus.DBusClient,
@@ -355,5 +358,23 @@ export class FridaScript {
      */
     async loadScript() {
         return this.agentSession.LoadScript(this.scriptId);
+    }
+
+    /**
+     * Send a message to the script.
+     * @param message - The message object to send, will be JSON stringified.
+     * @param data - Optional binary data to send along with the message.
+     * @returns Promise that resolves when the message is posted.
+     */
+    async post(message: any, data?: Buffer | null): Promise<void> {
+        return this.agentSession.PostMessages([
+            [
+                AgentMessageKind.Script,
+                this.scriptId,
+                JSON.stringify(message),
+                data != null,
+                data ?? ZERO_LENGTH_BUFFER,
+            ]
+        ], 0);
     }
 }


### PR DESCRIPTION
Not sure about the purpose of `batchId`, it seems to work OK with a hardcoded zero.
The zero length buffer is needed, because if you pass `null`, it fails somewhere further down due to the marshaller expecting an array:
```
C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:58
      for (var i = 0; i < data.length; ++i)
                               ^

TypeError: Cannot read properties of null (reading 'length')
    at write (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:58:32)
    at writeStruct (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:32:5)
    at write (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:42:7)
    at write (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:59:9)
    at writeStruct (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:32:5)
    at marshall (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\marshall.js:18:13)
    at Object.marshallMessage [as marshall] (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\message.js:86:16)
    at self.message (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\index.js:68:28)
    at bus.<anonymous> (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\bus.js:43:21)
    at bus.invoke (C:\github\httptoolkit\frida-js\node_modules\@httptoolkit\dbus-native\lib\promisify.js:12:16)
```
Lastly, the test suite is going to fail for this PR because it will fetch Frida v17, but `frida-js` only works with v16.